### PR TITLE
Update Go version to 1.24

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/example/go-streaming/api
 
-go 1.20
+go 1.24
 
 require github.com/gofiber/fiber/v2 v2.49.2
 

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.20
+go 1.24
 
-toolchain go1.23.4
+toolchain go1.24
 
 use (
 	./api

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -1,5 +1,5 @@
 module github.com/example/go-streaming/processor
 
-go 1.20
+go 1.24
 
 require github.com/segmentio/kafka-go v0.4.36

--- a/watcher/go.mod
+++ b/watcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/example/go-streaming/watcher
 
-go 1.20
+go 1.24
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0


### PR DESCRIPTION
## Summary
- bump Go toolchain to 1.24
- update modules to require Go 1.24

## Testing
- `go mod tidy` *(fails: go >= 1.24 required)*
- `go build ./...` *(fails: go >= 1.24 required)*

------
https://chatgpt.com/codex/tasks/task_e_684eff445580833182af8a7ee73d9697